### PR TITLE
refactor: adjust name; TGQuotientSequencesAdjacencyMatrix  -> TGQuotientSequencesStructure

### DIFF
--- a/autodoc/fileformats.autodoc
+++ b/autodoc/fileformats.autodoc
@@ -430,18 +430,18 @@ HyperCells HCS version 1.0
 @SectionLabel FileFormatHyperCellsExtensions
 
 In addition, the following file formats are introduced by the HyperCells package:
-- **HyperCell adjacency matrix** (`*.hcqs`) for storing the adjacency matrices, i.e.,
-   `TGQuotientSequencesAdjacencyMatrix` objects (see <Ref Sect='Section_TGQuotientSequencesAdjacencyMatrix'/>)
+- **HyperCell quotient sequences structure** (`*.hcqs`) for storing the adjacency matrices, i.e.,
+   `TGQuotientSequencesStructure` objects (see <Ref Sect='Section_TGQuotientSequencesStructure'/>)
 - **HyperCell point-group matrices** (`*.hcpgm`) for storing the point-group matrices, i.e.,
    `PGMatrices` objects (see <Ref Sect='Section_PGMatrices'/>)
 
 These file formats are described in detail below.
 
 
-@Subsection HyperCell adjacency matrix (*.hcqs)
-@SubsectionLabel FileFormatTGQuotientSequencesAdjacencyMatrix
+@Subsection HyperCell quotient sequences structure (*.hcqs)
+@SubsectionLabel FileFormatTGQuotientSequencesStructure
 
-The basic file structure of a HyperCell adjacency matrix file is as follows
+The basic file structure of a HyperCell quotient sequences structure file is as follows
 (with placeholders marked by `&lt;...&gt;`):
 
 @BeginLogSession
@@ -465,7 +465,7 @@ an ordered binary list of ones and zeros, 1 if quotients in `&lt;quotients&gt;` 
 The sixth line `&lt;sparse&gt;` specifies if line seven, the adjacency matrix `&lt;adjacency matrix&gt;`, is sparsly
 represented `true`, or dense `false`.
 
-The full file structure of a HyperCell adjacency matrix file thus is as follows:
+The full file structure of a HyperCell quotient sequences structure file thus is as follows:
 
 @BeginLogSession
 HyperCells HCQS version 1.0
@@ -477,7 +477,7 @@ HyperCells HCQS version 1.0
 [ entry1, entry2, ... ]
 @EndLogSession
 
-A complete example for a dense adjacency matrix for the 
+A complete example for a quotient sequences structure with a dense adjacency matrix for the 
 $\Delta(2,8,8)$ triangle group and triangle group quotients with genus smaller than 12
 is given below:
 @BeginLogSession
@@ -504,7 +504,7 @@ false
   [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ] ])
 @EndLogSession
 
-A complete example for a sparse representation of the adjacency matrix for the 
+A complete example for a sparse representation of the adjacency matrix in the quotient sequences structure for the 
 $\Delta(2,8,8)$ triangle group and triangle group quotients with genus smaller than 12
 is given below:
 @BeginLogSession
@@ -542,7 +542,7 @@ HyperCells HCPGM version 1.0
 The first line specifies the file format and its version. The second line gives the signature $(r,q,p)$ of the underlying 
 triangle group $\Delta(r,q,p)$ and the third line gives the triangle group quotient. The forth line `&lt;sparse&gt;` specifies
 if line five and six containing the point-group matrices `&lt;abcPGMats&gt;` and `&lt;symPGMats&gt;`, respectively, are 
-sparsly represented `true`, or dense `false`.
+sparsely represented `true`, or dense `false`.
 
 The full file structure of a HyperCell point-group matrices file thus is as follows:
 

--- a/autodoc/fileformats.autodoc
+++ b/autodoc/fileformats.autodoc
@@ -504,7 +504,7 @@ false
   [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ] ])
 @EndLogSession
 
-A complete example for a sparse representation of the adjacency matrix in the quotient sequences structure for the 
+A complete example for a sparse representation of the adjacency matrix of the quotient sequences structure for the 
 $\Delta(2,8,8)$ triangle group and triangle group quotients with genus smaller than 12
 is given below:
 @BeginLogSession

--- a/gap/TGQuotientSequences.gd
+++ b/gap/TGQuotientSequences.gd
@@ -15,7 +15,7 @@
 #!
 #! To check whether a given sequence of triangle-group quotients is valid, i.e.,
 #! whether the corresponding translation groups form a normal sequence as described
-#! above, the following functio can be used:
+#! above, the following function can be used:
 #!
 #! @Description
 #!   returns true if the given list of `TGQuotient` objects
@@ -28,33 +28,33 @@ DeclareGlobalFunction( "IsTGQuotientSequence" );
 
 
 #! @Section Constructing Sequences of Triangle-Group Quotients
-#! @SectionLabel TGQuotientSequencesAdjacencyMatrix
+#! @SectionLabel TGQuotientSequencesStructure
 #!
 #!   Sequences of quotient groups can efficiently be identified through the construction of adjacency
 #!   matrices that capture the normal subgroup relation between pairwise distinct translation groups 
 #!   of corresponding quotients. 
 #!
-#!   The adjacency matrix is implemented as an object of category `TGQuotientSequencesAdjacencyMatrix` with the following
-#!   components:
-#!   - <Ref Oper='Signature' Label='for TGQuotientSequencesAdjacencyMatrix' />:
+#!   The quotient sequences structure is implemented as an object of category `TGQuotientSequencesStructure`
+#!   with the following components:
+#!   - <Ref Oper='Signature' Label='for TGQuotientSequencesStructure' />:
 #!     signature of the underlying triangle group
-#!   - <Ref Oper='BoundByGenus' Label='for TGQuotientSequencesAdjacencyMatrix' />:
+#!   - <Ref Oper='BoundByGenus' Label='for TGQuotientSequencesStructure' />:
 #!     upper bound of the triangle group quotient genus
-#!   - <Ref Oper='GetListTGQuotients' Label='for TGQuotientSequencesAdjacencyMatrix' />:
+#!   - <Ref Oper='GetListTGQuotients' Label='for TGQuotientSequencesStructure' />:
 #!     list of quotients with genus smaller than upper bound of the triangle group quotient genus
-#!   - <Ref Oper='MirrorSymmetries' Label='for TGQuotientSequencesAdjacencyMatrix' />:
+#!   - <Ref Oper='MirrorSymmetries' Label='for TGQuotientSequencesStructure' />:
 #!     binary list, 1 if quotients have mirror symmetries 0 otherwise
-#!   - <Ref Oper='IsSparse' Label='for TGQuotientSequencesAdjacencyMatrix' />:
+#!   - <Ref Oper='IsSparse' Label='for TGQuotientSequencesStructure' />:
 #!     boolean, if true the adjacency matrix is sparsely represented
-#!   - <Ref Oper='AdjacencyMatrix' Label='for TGQuotientSequencesAdjacencyMatrix' />:
+#!   - <Ref Oper='AdjacencyMatrix' Label='for TGQuotientSequencesStructure' />:
 #!     adjacency matrix, which includes all quotients with and without mirror symmetries
-#!   - <Ref Oper='NearestNeighborAdjacencyMatrix' Label='for TGQuotientSequencesAdjacencyMatrix' />:
+#!   - <Ref Oper='NearestNeighborAdjacencyMatrix' Label='for TGQuotientSequencesStructure' />:
 #!     adjacency matrix of normal subgroup relation between consecutive translation groups of corresponding quotients
-#!   - <Ref Oper='LongestSequence' Label='for TGQuotientSequencesAdjacencyMatrix' />:
+#!   - <Ref Oper='LongestSequence' Label='for TGQuotientSequencesStructure' />:
 #!     list of longest sequence of quotient groups 
 #!   and is printed in the form
 #!   @BeginLog
-#!   TGQuotientSequencesAdjacencyMatrix( 
+#!   TGQuotientSequencesStructure( 
 #!     [r, q, p], 
 #!     boundByGenus = int,
 #!     lstTGQuotients = [[genus, number], ... ],
@@ -64,78 +64,79 @@ DeclareGlobalFunction( "IsTGQuotientSequence" );
 #!   )
 #!   @EndLog
   
-DeclareCategory( "IsTGQuotientSequencesAdjacencyMatrixObj", IsObject );
+DeclareCategory( "IsTGQuotientSequencesStructureObj", IsObject );
 
 #! @Description
-#!   Construct the adjacency matrix for the triangle group <A>tg</A> ($\Delta^+$), given as `ProperTriangleGroup` object (see
-#!   <Ref Sect="Section_TriangleGroups"/>), for available quotients from the library, i.e., Conder’s list.
+#!   Construct the quotient sequences structure for the triangle group <A>tg</A> ($\Delta^+$), given as 
+#!   `ProperTriangleGroup` object (see <Ref Sect="Section_TriangleGroups"/>), for available quotients from the library, i.e., Conder’s list.
 #!
 #!   The option `boundByGenus`, an upper bound, can be passed, which takes a positive integer below 102, limiting the number of 
 #!   quotients considered. If a positive integer below 102 is provided, triangle group quotients with genus smaller than 
-#!   `boundByGenus` will be used, a value above 102 will default back to 102. The default is 102. 
+#!   `boundByGenus` will be used, a value above 102 will default back to 66. The default is 66. 
 #!   The option `sparse`, which takes a boolean, can be used to generate a sparse representation of the adjacency matrix.
 #!   If sparse is true the adjacency matrix is of the form `[ [ [ rowIdx, colIdx ], entry ], ... ]`, where `entry`
 #!   is the corresponding matrix entry at position `rowIdx` and `colIdx`, which represent indices of the matrix 
 #!   rows and columns, respectively. The default is false.
 #!
-#!   This function saves constrcuted translation groups in cache, which can be flushed
+#!   This function saves constructed translation groups in cache, which can be flushed
 #!   by calling `FlushCaches` (see section Mutability and Copying in the <URL Text="GAP Reference Manual ">https://docs.gap-system.org/doc/ref/chap0_mj.html</URL>).
 #! @Arguments tg
-#! @Returns adjacency matrix as `TGQuotientSequencesAdjacencyMatrix` object.
-DeclareGlobalFunction( "TGQuotientSequencesAdjacencyMatrix" );
+#! @Returns quotient sequences structure as `TGQuotientSequencesStructure` object.
+DeclareGlobalFunction( "TGQuotientSequencesStructure" );
 
 #! @Description
-#!   returns the signature of the triangle group associated with <A>tgQSAdjMat</A>.
+#!   returns the signature of the triangle group associated with the quotient sequences structure <A>tgQSS</A>.
 #!   `[ r, q, p ]`.
-#! @Arguments tgQSAdjMat
-#! @Label for TGQuotientSequencesAdjacencyMatrix
-DeclareOperation( "Signature", [ IsTGQuotientSequencesAdjacencyMatrixObj ] );
+#! @Arguments tgQSS
+#! @Label for TGQuotientSequencesStructure
+DeclareOperation( "Signature", [ IsTGQuotientSequencesStructureObj ] );
 
 #! @Description
-#!   returns the upper bound used to generate adjacency matrix <A>tgQSAdjMat</A>.
-#! @Arguments tgQSAdjMat
-#! @Label for TGQuotientSequencesAdjacencyMatrix
-DeclareOperation( "BoundByGenus", [ IsTGQuotientSequencesAdjacencyMatrixObj ] );
+#!   returns the upper bound used to generate the adjacency matrix in the quotient sequences structure <A>tgQSS</A>.
+#! @Arguments tgQSS
+#! @Label for TGQuotientSequencesStructure
+DeclareOperation( "BoundByGenus", [ IsTGQuotientSequencesStructureObj ] );
 
 #! @Description
-#!   returns the list of quotients used to generate adjacency matrix <A>tgQSAdjMat</A>.
-#!   If the option `boundByGenus` was used in the generation of <A>tgQSAdjMat</A>, a corresponding 
-#!   reduced list will be returned. The default is `ListTGQuotients(Signature(<A>tgQSAdjMat</A>))`.
-#! @Arguments tgQSAdjMat
-#! @Label for TGQuotientSequencesAdjacencyMatrix
-DeclareOperation( "GetListTGQuotients", [ IsTGQuotientSequencesAdjacencyMatrixObj ] );
+#!   returns the list of quotients used to generate the adjacency matrix in the quotient sequences structure<A>tgQSS</A>.
+#!   If the option `boundByGenus` was used in the generation of <A>tgQSS</A>, a corresponding 
+#!   reduced list will be returned. The default is `ListTGQuotients(Signature(<A>tgQSS</A>))`.
+#! @Arguments tgQSS
+#! @Label for TGQuotientSequencesStructure
+DeclareOperation( "GetListTGQuotients", [ IsTGQuotientSequencesStructureObj ] );
 
 #! @Description
 #!   returns an ordered binary list of ones and zeros, `1` if quotients have mirror symmetries `0` otherwise. 
-#!   The position of each entry corresponds to the position of quotients in the list `GetListTGQuotients(<A>tgQSAdjMat</A>)`.
-#! @Arguments tgQSAdjMat
-#! @Label for TGQuotientSequencesAdjacencyMatrix
-DeclareOperation( "MirrorSymmetries", [ IsTGQuotientSequencesAdjacencyMatrixObj ] );
+#!   The position of each entry corresponds to the position of quotients in the list `GetListTGQuotients(<A>tgQSS</A>)`.
+#! @Arguments tgQSS
+#! @Label for TGQuotientSequencesStructure
+DeclareOperation( "MirrorSymmetries", [ IsTGQuotientSequencesStructureObj ] );
 
 #! @Description
-#!   returns a boolean, `true` if the adjacency matrix in <A>tgQSAdjMat</A> is sparse `false` otherwise.
-#! @Arguments tgQSAdjMat
-#! @Label for TGQuotientSequencesAdjacencyMatrix
-DeclareOperation( "IsSparse", [ IsTGQuotientSequencesAdjacencyMatrixObj ] );
+#!   returns a boolean, `true` if the adjacency matrix in <A>tgQSS</A> is sparse `false` otherwise.
+#! @Arguments tgQSS
+#! @Label for TGQuotientSequencesStructure
+DeclareOperation( "IsSparse", [ IsTGQuotientSequencesStructureObj ] );
 
 #! @Description
-#!   returns the adjacency matrix of dimension `BoundByGenus(<A>tgQSAdjMat</A>)` x `BoundByGenus(<A>tgQSAdjMat</A>)`.  
-#!   If `IsSparse(<A>tgQSAdjMat</A>)` is true, the adjacency matrix will be sparsely represented `[ [ [ rowIdx, colIdx ], entry ], ... ]`, 
+#!   returns the adjacency matrix which captures the normal subgroup relation between pairwise distinct translation groups of corresponding quotients,
+#!   of dimension `Length(GetListTGQuotients(<A>tgQSS</A>))` x `Length(GetListTGQuotients(<A>tgQSS</A>))`.  
+#!   If `IsSparse(<A>tgQSS</A>)` is true, the adjacency matrix will be sparsely represented `[ [ [ rowIdx, colIdx ], entry ], ... ]`, 
 #!   where `entry` is the corresponding matrix entry at position `rowIdx` and `colIdx`, which represent indices of the matrix
 #!   rows and columns, respectively.
-#! @Arguments tgQSAdjMat
-#! @Label for TGQuotientSequencesAdjacencyMatrix
-DeclareOperation( "AdjacencyMatrix", [ IsTGQuotientSequencesAdjacencyMatrixObj ] );
+#! @Arguments tgQSS
+#! @Label for TGQuotientSequencesStructure
+DeclareOperation( "AdjacencyMatrix", [ IsTGQuotientSequencesStructureObj ] );
 
 #! @Description
-#!   returns the adjacency matrix of the normal subgroup relation between consecutive translation groups of corresponding quotients,
-#!   with dimensions `BoundByGenus(<A>tgQSAdjMat</A>)` x `BoundByGenus(<A>tgQSAdjMat</A>)`.  
-#!   If `IsSparse(<A>tgQSAdjMat</A>)` is true, the adjacency matrix will be sparsely represented `[ [ [ rowIdx, colIdx ], entry ], ... ]`,
+#!   returns the adjacency matrix which captures the normal subgroup relation between consecutive translation groups of corresponding quotients,
+#!   with dimensions `Length(GetListTGQuotients(<A>tgQSS</A>))` x `Length(GetListTGQuotients(<A>tgQSS</A>))`.  
+#!   If `IsSparse(<A>tgQSS</A>)` is true, the adjacency matrix will be sparsely represented `[ [ [ rowIdx, colIdx ], entry ], ... ]`,
 #!   where `entry` is the corresponding matrix entry at position `rowIdx` and `colIdx`, which represent indices of the matrix
 #!   rows and columns, respectively.
-#! @Arguments tgQSAdjMat
-#! @Label for TGQuotientSequencesAdjacencyMatrix
-DeclareOperation( "NearestNeighborAdjacencyMatrix", [ IsTGQuotientSequencesAdjacencyMatrixObj ] );
+#! @Arguments tgQSS
+#! @Label for TGQuotientSequencesStructure
+DeclareOperation( "NearestNeighborAdjacencyMatrix", [ IsTGQuotientSequencesStructureObj ] );
 
 #! @Description
 #!   returns a list of quotients of the form `[[genus, number], ... ]` a normal sequence as described above.
@@ -146,9 +147,9 @@ DeclareOperation( "NearestNeighborAdjacencyMatrix", [ IsTGQuotientSequencesAdjac
 #!   list of the quotient. The default is 0, i.e., no first quotient specified.
 #!   The option `nonMirrorSymmetric`, which takes a boolean, enables that the list of quotients includes 
 #!   quotients that have no mirror symmetries.
-#! @Arguments tgQSAdjMat
-#! @Label for TGQuotientSequencesAdjacencyMatrix
-DeclareOperation( "LongestSequence", [ IsTGQuotientSequencesAdjacencyMatrixObj ] );
+#! @Arguments tgQSS
+#! @Label for TGQuotientSequencesStructure
+DeclareOperation( "LongestSequence", [ IsTGQuotientSequencesStructureObj ] );
 
 
 #! @Section Extending Quotient Sequences
@@ -196,55 +197,55 @@ DeclareGlobalFunction( "ExtendTGQuotientSequencesWithMinimalIndex" );
 #!
 #! @Section Export and Import
 
-#! @BeginGroup ExportTGQuotientSequencesAdjacencyMatrix
-#! @GroupTitle Exporting TGQuotientSequencesAdjacencyMatrix Objects
+#! @BeginGroup ExportTGQuotientSequencesStructure
+#! @GroupTitle Exporting TGQuotientSequencesStructure Objects
 #!
 #! @Description
-#!   Export the adjacency matrix `TGQuotientSequencesAdjacencyMatrix` <A>tgQSAdjMat</A> to the `OutputTextStream`  
+#!   Export the quotient sequences structure `TGQuotientSequencesStructure` <A>tgQSS</A> to the `OutputTextStream`  
 #!   <A>output-stream</A>
-#! @Arguments tgQSAdjMat, output-stream
-#! @Label for TGQuotientSequencesAdjacencyMatrix, OutputTextStream
-DeclareOperation( "Export", [ IsTGQuotientSequencesAdjacencyMatrixObj, IsOutputTextStream ] );
+#! @Arguments tgQSS, output-stream
+#! @Label for TGQuotientSequencesStructure, OutputTextStream
+DeclareOperation( "Export", [ IsTGQuotientSequencesStructureObj, IsOutputTextStream ] );
 #!
 #! @Description
 #!   or to the file at the path given by the string <A>path</A>.
-#! @Arguments tgQSAdjMat, path
-#! @Label for TGQuotientSequencesAdjacencyMatrix, String
-DeclareOperation( "Export", [ IsTGQuotientSequencesAdjacencyMatrixObj, IsString ] );
+#! @Arguments tgQSS, path
+#! @Label for TGQuotientSequencesStructure, String
+DeclareOperation( "Export", [ IsTGQuotientSequencesStructureObj, IsString ] );
 #!
 #! @Description
-#!   Alterantively, the adjacency matrix can be exported to a string with
+#!   Alternatively, the quotient sequences structure can be exported to a string with
 #!   `ExportString`, which returns said string.
-#! @Arguments tgQSAdjMat
-#! @Label for TGQuotientSequencesAdjacencyMatrix
-DeclareOperation( "ExportString", [ IsTGQuotientSequencesAdjacencyMatrixObj ] );
+#! @Arguments tgQSS
+#! @Label for TGQuotientSequencesStructure
+DeclareOperation( "ExportString", [ IsTGQuotientSequencesStructureObj ] );
 #!
 #! @EndGroup
 
 #!
-#! @BeginGroup ImportTGQuotientSequencesAdjacencyMatrix
-#! @GroupTitle Importing TGQuotientSequencesAdjacencyMatrix Objects
+#! @BeginGroup ImportTGQuotientSequencesStructure
+#! @GroupTitle Importing TGQuotientSequencesStructure Objects
 #!
 #! @Description
-#!   Import an adjacency matrix from the `InputTextStream` <A>input-stream</A>
+#!   Import an the quotient sequences structure from the `InputTextStream` <A>input-stream</A>
 #! @Arguments input-stream
-#! @Returns adjacency matrix as `TGQuotientSequencesAdjacencyMatrix`
-#! (see <Ref Sect='Section_TGQuotientSequencesAdjacencyMatrix'/>).
-DeclareGlobalFunction( "ImportTGQuotientSequencesAdjacencyMatrix" );
+#! @Returns quotient sequences structure as `TGQuotientSequencesStructure`
+#! (see <Ref Sect='Section_TGQuotientSequencesStructure'/>).
+DeclareGlobalFunction( "ImportTGQuotientSequencesStructure" );
 #!
 #! @Description
 #!   or from the file at the path given by the string <A>path</A>.
 #! @Arguments path
-#! @Returns adjacency matrix as `TGQuotientSequencesAdjacencyMatrix`
-#! (see <Ref Sect='Section_TGQuotientSequencesAdjacencyMatrix'/>).
-DeclareGlobalFunction( "ImportTGQuotientSequencesAdjacencyMatrixFromFile" );
+#! @Returns the quotient sequences structure as `TGQuotientSequencesStructure`
+#! (see <Ref Sect='Section_TGQuotientSequencesStructure'/>).
+DeclareGlobalFunction( "ImportTGQuotientSequencesStructureFromFile" );
 #!
 #! @Description
-#!   Alterantively, the adjacency matrix can be imported from the string <A>string</A>.
+#!   Alternatively, the the quotient sequences structure can be imported from the string <A>string</A>.
 #! @Arguments string
-#! @Returns adjacency matrix as `TGQuotientSequencesAdjacencyMatrix`
-#! (see <Ref Sect='Section_TGQuotientSequencesAdjacencyMatrix'/>).
-DeclareGlobalFunction( "ImportTGQuotientSequencesAdjacencyMatrixFromString" );
+#! @Returns the quotient sequences structure as `TGQuotientSequencesStructure`
+#! (see <Ref Sect='Section_TGQuotientSequencesStructure'/>).
+DeclareGlobalFunction( "ImportTGQuotientSequencesStructureFromString" );
 #!
 #! @EndGroup
 

--- a/gap/TGQuotientSequences.gd
+++ b/gap/TGQuotientSequences.gd
@@ -92,13 +92,13 @@ DeclareGlobalFunction( "TGQuotientSequencesStructure" );
 DeclareOperation( "Signature", [ IsTGQuotientSequencesStructureObj ] );
 
 #! @Description
-#!   returns the upper bound used to generate the adjacency matrix in the quotient sequences structure <A>tgQSS</A>.
+#!   returns the upper bound used to generate the adjacency matrix of the quotient sequences structure <A>tgQSS</A>.
 #! @Arguments tgQSS
 #! @Label for TGQuotientSequencesStructure
 DeclareOperation( "BoundByGenus", [ IsTGQuotientSequencesStructureObj ] );
 
 #! @Description
-#!   returns the list of quotients used to generate the adjacency matrix in the quotient sequences structure<A>tgQSS</A>.
+#!   returns the list of quotients used to generate the adjacency matrix of the quotient sequences structure<A>tgQSS</A>.
 #!   If the option `boundByGenus` was used in the generation of <A>tgQSS</A>, a corresponding 
 #!   reduced list will be returned. The default is `ListTGQuotients(Signature(<A>tgQSS</A>))`.
 #! @Arguments tgQSS

--- a/gap/TGQuotientSequences.gi
+++ b/gap/TGQuotientSequences.gi
@@ -429,72 +429,72 @@ function(sequence)
 end );
 
 
-# Type TGQuotientSequencesAdjacencyMatrix
-DeclareRepresentation("IsTGQuotientSequencesAdjacencyMatrixComponentRep", IsComponentObjectRep,
+# Type TGQuotientSequencesStructure
+DeclareRepresentation("IsTGQuotientSequencesStructureComponentRep", IsComponentObjectRep,
 	[ "signature", "boundByGenus", "lstTGQuotients", "lstMirrorSymmetries", "sparse", "adjMatrix" ]
 );
 
 
 InstallMethod( \=, [
-    IsTGQuotientSequencesAdjacencyMatrixObj and IsTGQuotientSequencesAdjacencyMatrixComponentRep,
-    IsTGQuotientSequencesAdjacencyMatrixObj and IsTGQuotientSequencesAdjacencyMatrixComponentRep ], 
-function(tgQSAdjMat1, tgQSAdjMat2)
-	return 	Signature(tgQSAdjMat1) = Signature(tgQSAdjMat2) and
-		BoundByGenus(tgQSAdjMat1) = BoundByGenus(tgQSAdjMat2) and
-		GetListTGQuotients(tgQSAdjMat1) = GetListTGQuotients(tgQSAdjMat2) and
-		MirrorSymmetries(tgQSAdjMat1) = MirrorSymmetries(tgQSAdjMat2) and
-		AdjacencyMatrix(tgQSAdjMat1) = AdjacencyMatrix(tgQSAdjMat2);
+    IsTGQuotientSequencesStructureObj and IsTGQuotientSequencesStructureComponentRep,
+    IsTGQuotientSequencesStructureObj and IsTGQuotientSequencesStructureComponentRep ], 
+function(tgQSS1, tgQSS2)
+	return 	Signature(tgQSS1) = Signature(tgQSS2) and
+		BoundByGenus(tgQSS1) = BoundByGenus(tgQSS2) and
+		GetListTGQuotients(tgQSS1) = GetListTGQuotients(tgQSS2) and
+		MirrorSymmetries(tgQSS1) = MirrorSymmetries(tgQSS2) and
+		AdjacencyMatrix(tgQSS1) = AdjacencyMatrix(tgQSS2);
 end );
 
 
 
-InstallMethod( Signature, [ IsTGQuotientSequencesAdjacencyMatrixObj and IsTGQuotientSequencesAdjacencyMatrixComponentRep ], 
-function(tgQSAdjMat)
-	return tgQSAdjMat!.signature;
+InstallMethod( Signature, [ IsTGQuotientSequencesStructureObj and IsTGQuotientSequencesStructureComponentRep ], 
+function(tgQSS)
+	return tgQSS!.signature;
 end );
 
-InstallMethod( BoundByGenus, [ IsTGQuotientSequencesAdjacencyMatrixObj and IsTGQuotientSequencesAdjacencyMatrixComponentRep ], 
-function(tgQSAdjMat)
-	return tgQSAdjMat!.boundByGenus;
+InstallMethod( BoundByGenus, [ IsTGQuotientSequencesStructureObj and IsTGQuotientSequencesStructureComponentRep ], 
+function(tgQSS)
+	return tgQSS!.boundByGenus;
 end );
 
-InstallMethod( GetListTGQuotients, [ IsTGQuotientSequencesAdjacencyMatrixObj and IsTGQuotientSequencesAdjacencyMatrixComponentRep ], 
-function(tgQSAdjMat)
-	return tgQSAdjMat!.lstTGQuotients;
+InstallMethod( GetListTGQuotients, [ IsTGQuotientSequencesStructureObj and IsTGQuotientSequencesStructureComponentRep ], 
+function(tgQSS)
+	return tgQSS!.lstTGQuotients;
 end );
 
-InstallMethod( MirrorSymmetries, [ IsTGQuotientSequencesAdjacencyMatrixObj and IsTGQuotientSequencesAdjacencyMatrixComponentRep ], 
-function(tgQSAdjMat)
-	return tgQSAdjMat!.lstMirrorSymmetries;
+InstallMethod( MirrorSymmetries, [ IsTGQuotientSequencesStructureObj and IsTGQuotientSequencesStructureComponentRep ], 
+function(tgQSS)
+	return tgQSS!.lstMirrorSymmetries;
 end );
 
-InstallMethod( IsSparse, [ IsTGQuotientSequencesAdjacencyMatrixObj and IsTGQuotientSequencesAdjacencyMatrixComponentRep ], 
-function(tgQSAdjMat)
-	return tgQSAdjMat!.sparse;
+InstallMethod( IsSparse, [ IsTGQuotientSequencesStructureObj and IsTGQuotientSequencesStructureComponentRep ], 
+function(tgQSS)
+	return tgQSS!.sparse;
 end );
 
-InstallMethod( AdjacencyMatrix, [ IsTGQuotientSequencesAdjacencyMatrixObj and IsTGQuotientSequencesAdjacencyMatrixComponentRep ], 
-function(tgQSAdjMat)
-	return tgQSAdjMat!.adjMatrix;
+InstallMethod( AdjacencyMatrix, [ IsTGQuotientSequencesStructureObj and IsTGQuotientSequencesStructureComponentRep ], 
+function(tgQSS)
+	return tgQSS!.adjMatrix;
 end );
 
 
 
-InstallMethod( PrintString, [ IsTGQuotientSequencesAdjacencyMatrixObj and IsTGQuotientSequencesAdjacencyMatrixComponentRep ], 
-function(tgQSAdjMat)
-	return Concatenation( "TGQuotientSequencesAdjacencyMatrix( ", 
-		PrintString(Signature(tgQSAdjMat)), ", ",
-		"boundByGenus = ", PrintString(BoundByGenus(tgQSAdjMat)), ", ",
-		"ListTGQuotients = ", PrintString(GetListTGQuotients(tgQSAdjMat)), ", ",
-		"MirrorSymmetries = ", PrintString(MirrorSymmetries(tgQSAdjMat)), ", ",
-		"sparse = ", PrintString(IsSparse(tgQSAdjMat)), ", ",
-		"adjMatrix = ", PrintString(AdjacencyMatrix(tgQSAdjMat)), 
+InstallMethod( PrintString, [ IsTGQuotientSequencesStructureObj and IsTGQuotientSequencesStructureComponentRep ], 
+function(tgQSS)
+	return Concatenation( "TGQuotientSequencesStructure( ", 
+		PrintString(Signature(tgQSS)), ", ",
+		"boundByGenus = ", PrintString(BoundByGenus(tgQSS)), ", ",
+		"ListTGQuotients = ", PrintString(GetListTGQuotients(tgQSS)), ", ",
+		"MirrorSymmetries = ", PrintString(MirrorSymmetries(tgQSS)), ", ",
+		"sparse = ", PrintString(IsSparse(tgQSS)), ", ",
+		"adjMatrix = ", PrintString(AdjacencyMatrix(tgQSS)), 
 	")" );
 end );
 
-InstallMethod( PrintObj, [ IsTGQuotientSequencesAdjacencyMatrixObj and IsTGQuotientSequencesAdjacencyMatrixComponentRep ], 
-function(tgQSAdjMat)
-	Print(PrintString(tgQSAdjMat));
+InstallMethod( PrintObj, [ IsTGQuotientSequencesStructureObj and IsTGQuotientSequencesStructureComponentRep ], 
+function(tgQSS)
+	Print(PrintString(tgQSS));
 end );
 
 
@@ -510,7 +510,7 @@ toIndex@ := function(IndexLst)
 	return Int(JoinStringsWithSeparator(List(IndexLst, x -> String(x)),""));
 end;
 
-InstallGlobalFunction( TGQuotientSequencesAdjacencyMatrix,
+InstallGlobalFunction( TGQuotientSequencesStructure,
 function(tg)
 	local signature, conderIndexLst, boundByGenus, lenConder, adjMat, i, j, k, l, 
          Quot1, Quot2, genus1, genus2, switch1, switch2, GAMMA1, GAMMA2, sparse, F, 
@@ -538,13 +538,13 @@ function(tg)
 	# upper bound of triangle group quotients genus
 	boundByGenus := ValueOption("boundByGenus");
 	if boundByGenus = fail then
-		boundByGenus := 102; # Max. in Conder's list 101.
+		boundByGenus := 66; # Max. in Conder's list 101.
 	elif not IsPosInt(boundByGenus) then
 		Error(StringFormatted("boundByGenus {} is not a positive integer.", boundByGenus));
 	        return fail;
 	elif boundByGenus > 102 then
-		Print(StringFormatted("boundByGenus {} exceeded the upper bound 102, the default value 102 was used instead.", boundByGenus));
-		boundByGenus := 102; # Max. in Conder's list 101.
+		Print(StringFormatted("boundByGenus {} exceeded the upper bound 102, the default value 66 was used instead.", boundByGenus));
+		boundByGenus := 66; # Max. in Conder's list 101.
 	fi;
 
 	# condition for sparse rep. of adjacency matrix
@@ -626,7 +626,7 @@ function(tg)
 				Quot1 := TGQuotient(conderIndexLst[i]);
 				genus1 := TGQuotientGenus(Quot1);
 				
-				# check Rieman-Hurwitz formula 
+				# check Riemann-Hurwitz formula 
 				if IsInt((genus2 - 1)/(genus1 - 1)) and genus2 > genus1 then
 
 					switch2 := 0;
@@ -700,7 +700,7 @@ function(tg)
 				Quot1 := TGQuotient(conderIndexLst[i]);
 				genus1 := TGQuotientGenus(Quot1);
 
-				# check Rieman-Hurwitz formula 
+				# check Riemann-Hurwitz formula 
 				if IsInt((genus2 - 1)/(genus1 - 1)) and genus2 > genus1 then
 
 					switch2 := 0;
@@ -730,8 +730,8 @@ function(tg)
 	 	od;
 	 fi;
     
-	F := NewFamily( "TGQuotientSequencesAdjacencyMatrix", IsTGQuotientSequencesAdjacencyMatrixObj );
-    	return Objectify( NewType( F, IsTGQuotientSequencesAdjacencyMatrixObj and IsTGQuotientSequencesAdjacencyMatrixComponentRep ), rec(
+	F := NewFamily( "TGQuotientSequencesStructure", IsTGQuotientSequencesStructureObj );
+    	return Objectify( NewType( F, IsTGQuotientSequencesStructureObj and IsTGQuotientSequencesStructureComponentRep ), rec(
 		signature := MakeImmutable(signature),
 		boundByGenus := MakeImmutable(boundByGenus),
 		lstTGQuotients := MakeImmutable(conderIndexLst),
@@ -793,15 +793,15 @@ sparseMatSubtract@ := function(mat1, mat2)
 end;
 
 
-InstallMethod( NearestNeighborAdjacencyMatrix, [ IsTGQuotientSequencesAdjacencyMatrixObj and IsTGQuotientSequencesAdjacencyMatrixComponentRep ], 
-function(tgQSAdjMat)
+InstallMethod( NearestNeighborAdjacencyMatrix, [ IsTGQuotientSequencesStructureObj and IsTGQuotientSequencesStructureComponentRep ], 
+function(tgQSS)
 	local adjMat, NNadjMat;
 	
 	# get the adjacency matrix
-	adjMat := AdjacencyMatrix(tgQSAdjMat);
+	adjMat := AdjacencyMatrix(tgQSS);
 
 	# check for sparsity and subtract the signed matrix 2nd matrix power of adjMat from adjMat
-	if IsSparse(tgQSAdjMat) then	
+	if IsSparse(tgQSS) then	
 		NNadjMat := sparseMatSubtract@(adjMat,sparseMatMultiply@(adjMat,adjMat : signed := true));
 	else 
 		NNadjMat := adjMat - signMatrix@(adjMat*adjMat);
@@ -829,18 +829,18 @@ dfs@ := function(quotient, adjLst, idxLst, visited)
 end;
 
 
-InstallMethod( LongestSequence, [ IsTGQuotientSequencesAdjacencyMatrixObj and IsTGQuotientSequencesAdjacencyMatrixComponentRep ], 
-function(tgQSAdjMat)
+InstallMethod( LongestSequence, [ IsTGQuotientSequencesStructureObj and IsTGQuotientSequencesStructureComponentRep ], 
+function(tgQSS)
 	local adjMat, NNadjMat, quotient, lstTGQuotients, sparse, adjLst, idxLst, 
 	 visited, N, i, j, entry, mspLst, nonMirrorSymmetric;
 
 	# Needed objects:
 	# ---------------
 
-	adjMat := NearestNeighborAdjacencyMatrix(tgQSAdjMat); 
-	lstTGQuotients := GetListTGQuotients(tgQSAdjMat); 
-	mspLst := MirrorSymmetries(tgQSAdjMat);
-	sparse := IsSparse(tgQSAdjMat);
+	adjMat := NearestNeighborAdjacencyMatrix(tgQSS); 
+	lstTGQuotients := GetListTGQuotients(tgQSS); 
+	mspLst := MirrorSymmetries(tgQSS);
+	sparse := IsSparse(tgQSS);
 	N := Length(lstTGQuotients);
 
 	# --------
@@ -861,7 +861,7 @@ function(tgQSAdjMat)
 			Error(StringFormatted("Quotient {} is not an element in {}.", quotient, lstTGQuotients));
         		return fail;
 		else
-			quotient := Position(GetListTGQuotients(tgQSAdjMat), quotient);
+			quotient := Position(GetListTGQuotients(tgQSS), quotient);
 		fi;
 	elif not quotient <= Length(lstTGQuotients) and not quotient = 0 then
 		Error(StringFormatted("Quotient {} exceeds the number of elements {} in the list of quotient.", quotient, Length(lstTGQuotients)));
@@ -881,7 +881,7 @@ function(tgQSAdjMat)
 	# quotients having mirror symmetries are included, an error will be raised
 	if not nonMirrorSymmetric and not quotient = 0 then
 		if mspLst[quotient] = 0 then
-			Error("This quotinet does not have mirror symmetries.\n");
+			Error("This quotient does not have mirror symmetries.\n");
 			Print("Set option nonMirrorSymmetric to true if you want to include quotients without mirror symmetries.");
 			return fail;
 		fi;
@@ -946,8 +946,8 @@ function(tgQSAdjMat)
 end );
 
 
-InstallMethod( Export, [  IsTGQuotientSequencesAdjacencyMatrixObj, IsOutputTextStream ],
-function(tgQSAdjMat, output)
+InstallMethod( Export, [  IsTGQuotientSequencesStructureObj, IsOutputTextStream ],
+function(tgQSS, output)
 
     SetPrintFormattingStatus(output, false);
     
@@ -956,37 +956,37 @@ function(tgQSAdjMat, output)
 	AppendTo(output, "\n");
 
     # write: triangle group, genus bound, list of quotients
-	AppendTo(output, Signature(tgQSAdjMat));
+	AppendTo(output, Signature(tgQSS));
 	AppendTo(output, "\n");
-	AppendTo(output, BoundByGenus(tgQSAdjMat));
+	AppendTo(output, BoundByGenus(tgQSS));
 	AppendTo(output, "\n");
-	AppendTo(output, GetListTGQuotients(tgQSAdjMat));
+	AppendTo(output, GetListTGQuotients(tgQSS));
 	AppendTo(output, "\n");
-	AppendTo(output, MirrorSymmetries(tgQSAdjMat));
+	AppendTo(output, MirrorSymmetries(tgQSS));
 	AppendTo(output, "\n");
-	AppendTo(output, IsSparse(tgQSAdjMat));
+	AppendTo(output, IsSparse(tgQSS));
 	AppendTo(output, "\n");
 
     # write: adjacency matrix
-	AppendTo(output, AdjacencyMatrix(tgQSAdjMat));
+	AppendTo(output, AdjacencyMatrix(tgQSS));
 end );
 
-InstallMethod( Export, [ IsTGQuotientSequencesAdjacencyMatrixObj, IsString ],
-function(tgQSAdjMat, path)
+InstallMethod( Export, [ IsTGQuotientSequencesStructureObj, IsString ],
+function(tgQSS, path)
     local output;
 
     # open file
     output := OutputTextFile(path, false);
 
-    Export(tgQSAdjMat, output);
+    Export(tgQSS, output);
 
     # close file
     CloseStream(output);
 end );
 
 
-InstallMethod( ExportString, [ IsTGQuotientSequencesAdjacencyMatrixObj ],
-function(tgQSAdjMat)
+InstallMethod( ExportString, [ IsTGQuotientSequencesStructureObj ],
+function(tgQSS)
 	local str, output;
 
 	# open string stream
@@ -994,7 +994,7 @@ function(tgQSAdjMat)
 	output := OutputTextString(str, false);
 	
 	# export to stream
-	Export(tgQSAdjMat, output);
+	Export(tgQSS, output);
 
 	# close
 	CloseStream(output);
@@ -1005,7 +1005,7 @@ end );
 
 
 
-InstallGlobalFunction( ImportTGQuotientSequencesAdjacencyMatrix,
+InstallGlobalFunction( ImportTGQuotientSequencesStructure,
 function(input)
     local version, signature, boundByGenus, conderIndexLst, mspLst, 
      sparse, adjMat, F;
@@ -1027,8 +1027,8 @@ function(input)
 	adjMat := EvalString(ReadAllLine(input));
 	
 
-	F := NewFamily( "TGQuotientSequencesAdjacencyMatrix", IsTGQuotientSequencesAdjacencyMatrixObj );
-    	return Objectify( NewType( F, IsTGQuotientSequencesAdjacencyMatrixObj and IsTGQuotientSequencesAdjacencyMatrixComponentRep ), rec(
+	F := NewFamily( "TGQuotientSequencesStructure", IsTGQuotientSequencesStructureObj );
+    	return Objectify( NewType( F, IsTGQuotientSequencesStructureObj and IsTGQuotientSequencesStructureComponentRep ), rec(
 		signature := MakeImmutable(signature),
 		boundByGenus := MakeImmutable(boundByGenus),
 		lstTGQuotients := MakeImmutable(conderIndexLst),
@@ -1039,26 +1039,26 @@ function(input)
 end );
 
 
-InstallGlobalFunction( ImportTGQuotientSequencesAdjacencyMatrixFromFile,
+InstallGlobalFunction( ImportTGQuotientSequencesStructureFromFile,
 function(path)
-	local input, tgQSAdjMat;
+	local input, tgQSS;
 
 	# open input stream
 	input := InputTextFile(path);
 
 	# import
-	tgQSAdjMat := CallFuncList(ImportTGQuotientSequencesAdjacencyMatrix, [input]);
+	tgQSS := CallFuncList(ImportTGQuotientSequencesStructure, [input]);
 
 	# close stream
 	CloseStream(input);
 
-	return tgQSAdjMat;
+	return tgQSS;
 end );
 
 
-InstallGlobalFunction( ImportTGQuotientSequencesAdjacencyMatrixFromString,
+InstallGlobalFunction( ImportTGQuotientSequencesStructureFromString,
 function(string)
-	local input, tgQSAdjMat;
+	local input, tgQSS;
 
 	# check arguments
 	if not IsString(string) then
@@ -1070,12 +1070,12 @@ function(string)
 	input := InputTextString(string);
 	
 	# import
-	tgQSAdjMat := CallFuncList(ImportTGQuotientSequencesAdjacencyMatrix, [input]);
+	tgQSS := CallFuncList(ImportTGQuotientSequencesStructure, [input]);
 
 	# close stream
 	CloseStream(input);
 
-	return tgQSAdjMat;
+	return tgQSS;
 end );
 
 

--- a/tst/TGQuotientSequences.tst
+++ b/tst/TGQuotientSequences.tst
@@ -27,8 +27,8 @@ gap> tg := ProperTriangleGroup(sign);;
 gap> boundByGenus := 34;;
 
 gap> sparse := false;;
-gap> tgQSAdjMat := TGQuotientSequencesAdjacencyMatrix(tg : sparse := sparse, boundByGenus := boundByGenus );
-TGQuotientSequencesAdjacencyMatrix( [ 2, 4, 6 ], boundByGenus = 34, ListTGQuotients = [ [ 2, 2 ], [ 3, 4 ], [ 4, 3 ], \
+gap> tgQSS := TGQuotientSequencesStructure(tg : sparse := sparse, boundByGenus := boundByGenus );
+TGQuotientSequencesStructure( [ 2, 4, 6 ], boundByGenus = 34, ListTGQuotients = [ [ 2, 2 ], [ 3, 4 ], [ 4, 3 ], \
 [ 5, 4 ], [ 6, 2 ], [ 9, 3 ], [ 9, 4 ], [ 10, 8 ], [ 10, 9 ], [ 11, 1 ], [ 15, 5 ], [ 17, 4 ], [ 17, 5 ], [ 17, 6 ], [\
  17, 7 ], [ 21, 3 ], [ 28, 8 ], [ 29, 1 ], [ 31, 3 ], [ 33, 6 ], [ 33, 7 ], [ 33, 8 ], [ 33, 9 ], [ 33, 10 ], [ 33, 11\
  ] ], MirrorSymmetries = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1 ], sparse = false\
@@ -51,8 +51,8 @@ TGQuotientSequencesAdjacencyMatrix( [ 2, 4, 6 ], boundByGenus = 34, ListTGQuotie
  0, 0, 0, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ] ])
 
 gap> sparse := true;;
-gap> tgQSAdjMatSparse := TGQuotientSequencesAdjacencyMatrix(tg : sparse := sparse, boundByGenus := boundByGenus );
-TGQuotientSequencesAdjacencyMatrix( [ 2, 4, 6 ], boundByGenus = 34, ListTGQuotients = [ [ 2, 2 ], [ 3, 4 ], [ 4, 3 ], \
+gap> tgQSSSparse := TGQuotientSequencesStructure(tg : sparse := sparse, boundByGenus := boundByGenus );
+TGQuotientSequencesStructure( [ 2, 4, 6 ], boundByGenus = 34, ListTGQuotients = [ [ 2, 2 ], [ 3, 4 ], [ 4, 3 ], \
 [ 5, 4 ], [ 6, 2 ], [ 9, 3 ], [ 9, 4 ], [ 10, 8 ], [ 10, 9 ], [ 11, 1 ], [ 15, 5 ], [ 17, 4 ], [ 17, 5 ], [ 17, 6 ], [\
  17, 7 ], [ 21, 3 ], [ 28, 8 ], [ 29, 1 ], [ 31, 3 ], [ 33, 6 ], [ 33, 7 ], [ 33, 8 ], [ 33, 9 ], [ 33, 10 ], [ 33, 11\
  ] ], MirrorSymmetries = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1 ], sparse = true,\
@@ -67,31 +67,31 @@ TGQuotientSequencesAdjacencyMatrix( [ 2, 4, 6 ], boundByGenus = 34, ListTGQuotie
 , [ [ 13, 20 ], 1 ], [ [ 13, 23 ], 1 ], [ [ 14, 23 ], 1 ], [ [ 15, 23 ], 1 ], [ [ 15, 24 ], 1 ], [ [ 15, 25 ], 1 ] ])
 
 # Test basic properties
-gap> Signature(tgQSAdjMat);
+gap> Signature(tgQSS);
 [2, 4, 6]
-gap> Signature(tgQSAdjMatSparse);
+gap> Signature(tgQSSSparse);
 [2, 4, 6]
-gap> BoundByGenus(tgQSAdjMat);
+gap> BoundByGenus(tgQSS);
 34
-gap> BoundByGenus(tgQSAdjMatSparse);
+gap> BoundByGenus(tgQSSSparse);
 34
-gap> GetListTGQuotients(tgQSAdjMat);
+gap> GetListTGQuotients(tgQSS);
 [ [ 2, 2 ], [ 3, 4 ], [ 4, 3 ], [ 5, 4 ], [ 6, 2 ], [ 9, 3 ], [ 9, 4 ], [ 10, 8 ], [ 10, 9 ], [ 11, 1 ], [ 15, 5 ],
   [ 17, 4 ], [ 17, 5 ], [ 17, 6 ], [ 17, 7 ], [ 21, 3 ], [ 28, 8 ], [ 29, 1 ], [ 31, 3 ], [ 33, 6 ], [ 33, 7 ],
   [ 33, 8 ], [ 33, 9 ], [ 33, 10 ], [ 33, 11 ] ]
-gap> GetListTGQuotients(tgQSAdjMatSparse);
+gap> GetListTGQuotients(tgQSSSparse);
 [ [ 2, 2 ], [ 3, 4 ], [ 4, 3 ], [ 5, 4 ], [ 6, 2 ], [ 9, 3 ], [ 9, 4 ], [ 10, 8 ], [ 10, 9 ], [ 11, 1 ], [ 15, 5 ],
   [ 17, 4 ], [ 17, 5 ], [ 17, 6 ], [ 17, 7 ], [ 21, 3 ], [ 28, 8 ], [ 29, 1 ], [ 31, 3 ], [ 33, 6 ], [ 33, 7 ],
   [ 33, 8 ], [ 33, 9 ], [ 33, 10 ], [ 33, 11 ] ]
-gap> MirrorSymmetries(tgQSAdjMat);
+gap> MirrorSymmetries(tgQSS);
 [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1 ]
-gap> MirrorSymmetries(tgQSAdjMatSparse);
+gap> MirrorSymmetries(tgQSSSparse);
 [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1 ]
-gap> IsSparse(tgQSAdjMat);
+gap> IsSparse(tgQSS);
 false
-gap> IsSparse(tgQSAdjMatSparse);
+gap> IsSparse(tgQSSSparse);
 true
-gap> adjMat := AdjacencyMatrix(tgQSAdjMat);
+gap> adjMat := AdjacencyMatrix(tgQSS);
 [ [ 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 1, 1 ],
   [ 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1 ],
   [ 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
@@ -117,7 +117,7 @@ gap> adjMat := AdjacencyMatrix(tgQSAdjMat);
   [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
   [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
   [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ] ]
-gap> adjMatSparse := AdjacencyMatrix(tgQSAdjMatSparse);
+gap> adjMatSparse := AdjacencyMatrix(tgQSSSparse);
 [ [ [ 1, 4 ], 1 ], [ [ 1, 6 ], 1 ], [ [ 1, 9 ], 1 ], [ [ 1, 12 ], 1 ], [ [ 1, 15 ], 1 ], [ [ 1, 17 ], 1 ],
   [ [ 1, 21 ], 1 ], [ [ 1, 23 ], 1 ], [ [ 1, 24 ], 1 ], [ [ 1, 25 ], 1 ], [ [ 2, 4 ], 1 ], [ [ 2, 6 ], 1 ],
   [ [ 2, 7 ], 1 ], [ [ 2, 12 ], 1 ], [ [ 2, 13 ], 1 ], [ [ 2, 14 ], 1 ], [ [ 2, 15 ], 1 ], [ [ 2, 20 ], 1 ],
@@ -130,7 +130,7 @@ gap> adjMatSparse := AdjacencyMatrix(tgQSAdjMatSparse);
   [ [ 14, 23 ], 1 ], [ [ 15, 23 ], 1 ], [ [ 15, 24 ], 1 ], [ [ 15, 25 ], 1 ] ]
 
 # Nearest-neighbor adjacency matrix (test sparse multiplication and subtraction)
-gap> NearestNeighborAdjacencyMatrix(tgQSAdjMat);
+gap> NearestNeighborAdjacencyMatrix(tgQSS);
 [ [ 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
   [ 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
   [ 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
@@ -156,7 +156,7 @@ gap> NearestNeighborAdjacencyMatrix(tgQSAdjMat);
   [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
   [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
   [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ] ]
-gap> NearestNeighborAdjacencyMatrix(tgQSAdjMatSparse);
+gap> NearestNeighborAdjacencyMatrix(tgQSSSparse);
 [ [ [ 1, 4 ], 1 ], [ [ 1, 9 ], 1 ], [ [ 2, 4 ], 1 ], [ [ 2, 7 ], 1 ], [ [ 3, 8 ], 1 ], [ [ 3, 9 ], 1 ],
   [ [ 4, 6 ], 1 ], [ [ 4, 12 ], 1 ], [ [ 4, 15 ], 1 ], [ [ 5, 10 ], 1 ], [ [ 6, 21 ], 1 ], [ [ 6, 25 ], 1 ],
   [ [ 7, 13 ], 1 ], [ [ 7, 14 ], 1 ], [ [ 7, 15 ], 1 ], [ [ 7, 22 ], 1 ], [ [ 8, 17 ], 1 ], [ [ 9, 17 ], 1 ],
@@ -164,23 +164,23 @@ gap> NearestNeighborAdjacencyMatrix(tgQSAdjMatSparse);
   [ [ 14, 23 ], 1 ], [ [ 15, 23 ], 1 ], [ [ 15, 24 ], 1 ], [ [ 15, 25 ], 1 ] ]
 
 # Test depth first algorithm
-gap> LongestSequence(tgQSAdjMat);
+gap> LongestSequence(tgQSS);
 [ [ 2, 2 ], [ 5, 4 ], [ 9, 3 ], [ 33, 11 ] ]
-gap> LongestSequence(tgQSAdjMatSparse);
+gap> LongestSequence(tgQSSSparse);
 [ [ 2, 2 ], [ 5, 4 ], [ 9, 3 ], [ 33, 11 ] ]
-gap> LongestSequence(tgQSAdjMat : quotient := [17,5]);
+gap> LongestSequence(tgQSS : quotient := [17,5]);
 [ [ 17, 5 ], [ 33, 9 ] ]
-gap> LongestSequence(tgQSAdjMatSparse : quotient := [17,5]);
+gap> LongestSequence(tgQSSSparse : quotient := [17,5]);
 [ [ 17, 5 ], [ 33, 9 ] ]
-gap> LongestSequence(tgQSAdjMat : quotient := [17,5], nonMirrorSymmetric := true);
+gap> LongestSequence(tgQSS : quotient := [17,5], nonMirrorSymmetric := true);
 [ [ 17, 5 ], [ 33, 6 ] ]
-gap> LongestSequence(tgQSAdjMatSparse : quotient := [17,5], nonMirrorSymmetric := true);
+gap> LongestSequence(tgQSSSparse : quotient := [17,5], nonMirrorSymmetric := true);
 [ [ 17, 5 ], [ 33, 6 ] ]
 
 # Test export/import
 gap> str := "";;
 gap> output := OutputTextString(str, false);;
-gap> Export(tgQSAdjMat, output);;
+gap> Export(tgQSS, output);;
 gap> CloseStream(output);;
 gap> Print(str);
 HyperCells HCQS version 1.0
@@ -210,8 +210,8 @@ false
 , 0, 0 ], [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ] ]
 
 gap> input := InputTextString(str);;
-gap> tgQSAdjMat2 := ImportTGQuotientSequencesAdjacencyMatrix(input);
-TGQuotientSequencesAdjacencyMatrix( [ 2, 4, 6 ], boundByGenus = 34, ListTGQuotients = [ [ 2, 2 ], [ 3, 4 ], [ 4, 3 ], \
+gap> tgQSS2 := ImportTGQuotientSequencesStructure(input);
+TGQuotientSequencesStructure( [ 2, 4, 6 ], boundByGenus = 34, ListTGQuotients = [ [ 2, 2 ], [ 3, 4 ], [ 4, 3 ], \
 [ 5, 4 ], [ 6, 2 ], [ 9, 3 ], [ 9, 4 ], [ 10, 8 ], [ 10, 9 ], [ 11, 1 ], [ 15, 5 ], [ 17, 4 ], [ 17, 5 ], [ 17, 6 ], [\
  17, 7 ], [ 21, 3 ], [ 28, 8 ], [ 29, 1 ], [ 31, 3 ], [ 33, 6 ], [ 33, 7 ], [ 33, 8 ], [ 33, 9 ], [ 33, 10 ], [ 33, 11\
  ] ], MirrorSymmetries = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1 ], sparse = false\
@@ -232,13 +232,13 @@ TGQuotientSequencesAdjacencyMatrix( [ 2, 4, 6 ], boundByGenus = 34, ListTGQuotie
 0, 0, 0, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 0,\
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\
  0, 0, 0, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ] ])
-gap> tgQSAdjMat = tgQSAdjMat2;
+gap> tgQSS = tgQSS2;
 true
 
 # Test export/import (sparse)
 gap> str := "";;
 gap> output := OutputTextString(str, false);;
-gap> Export(tgQSAdjMatSparse, output);;
+gap> Export(tgQSSSparse, output);;
 gap> CloseStream(output);;
 gap> Print(str);
 HyperCells HCQS version 1.0
@@ -260,8 +260,8 @@ true
 ], 1 ], [ [ 13, 23 ], 1 ], [ [ 14, 23 ], 1 ], [ [ 15, 23 ], 1 ], [ [ 15, 24 ], 1 ], [ [ 15, 25 ], 1 ] ]
 
 gap> input := InputTextString(str);;
-gap> tgQSAdjMatSparse2 := ImportTGQuotientSequencesAdjacencyMatrix(input);
-TGQuotientSequencesAdjacencyMatrix( [ 2, 4, 6 ], boundByGenus = 34, ListTGQuotients = [ [ 2, 2 ], [ 3, 4 ], [ 4, 3 ], \
+gap> tgQSSSparse2 := ImportTGQuotientSequencesStructure(input);
+TGQuotientSequencesStructure( [ 2, 4, 6 ], boundByGenus = 34, ListTGQuotients = [ [ 2, 2 ], [ 3, 4 ], [ 4, 3 ], \
 [ 5, 4 ], [ 6, 2 ], [ 9, 3 ], [ 9, 4 ], [ 10, 8 ], [ 10, 9 ], [ 11, 1 ], [ 15, 5 ], [ 17, 4 ], [ 17, 5 ], [ 17, 6 ], [\
  17, 7 ], [ 21, 3 ], [ 28, 8 ], [ 29, 1 ], [ 31, 3 ], [ 33, 6 ], [ 33, 7 ], [ 33, 8 ], [ 33, 9 ], [ 33, 10 ], [ 33, 11\
  ] ], MirrorSymmetries = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1 ], sparse = true,\
@@ -274,7 +274,7 @@ TGQuotientSequencesAdjacencyMatrix( [ 2, 4, 6 ], boundByGenus = 34, ListTGQuotie
 [ [ 7, 14 ], 1 ], [ [ 7, 15 ], 1 ], [ [ 7, 20 ], 1 ], [ [ 7, 22 ], 1 ], [ [ 7, 23 ], 1 ], [ [ 7, 24 ], 1 ], [ [ 7, 25 \
 ], 1 ], [ [ 8, 17 ], 1 ], [ [ 9, 17 ], 1 ], [ [ 10, 16 ], 1 ], [ [ 10, 19 ], 1 ], [ [ 11, 18 ], 1 ], [ [ 12, 21 ], 1 ]\
 , [ [ 13, 20 ], 1 ], [ [ 13, 23 ], 1 ], [ [ 14, 23 ], 1 ], [ [ 15, 23 ], 1 ], [ [ 15, 24 ], 1 ], [ [ 15, 25 ], 1 ] ])
-gap> tgQSAdjMatSparse = tgQSAdjMatSparse2;
+gap> tgQSSSparse = tgQSSSparse2;
 true
 
 # Test internal (cache) functions


### PR DESCRIPTION
The name TGQuotientSequencesAdjacencyMatrix and related sentences in the documentation might cause unintended associations with the unrelated adjacency matrices of hyperbolic lattice sites. Thus, a corresponding change is suggested: TGQuotientSequencesAdjacencyMatrix  -> TGQuotientSequencesStructure as well as minor modifications in the documentation.

In addition, the default value for the option boundByGenus is reduced to 66 instead of the maximum value of 102 in order to increase the user-friendliness.