### PR TITLE
Update CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,6 +49,7 @@ jobs:
       - uses: gap-actions/build-pkg-docs@v1
         with:
           use-latex: 'true'
+          warnings-as-errors: 'false'
       - name: 'Upload documentation'
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Ignore all warnings when building the documentation using the gap-actions/build-pkg-docs worflow. The warnings causing an issue are multiply defined labels in the LaTeX output.