### PR TITLE
chore: updated deprecated edge tags

### DIFF
--- a/autodoc/introduction.autodoc
+++ b/autodoc/introduction.autodoc
@@ -115,8 +115,8 @@ TGCellModelGraph(
     center = 3,
     type = [ "TESS", [ 8, 8 ], [ "VEF", [ [ 3 ], [ 1 ], [ 2 ] ] ] ],
     vertices = [ [ 3, 1 ] ],
-    edges = [ [ 1, 1, [ 1, [ 1, 1, 5 ] ], g1 ], [ 1, 1, [ 1, [ 2, 4, 8 ] ], g4 ],
-        [ 1, 1, [ 1, [ 3, 2, 6 ] ], g2 ], [ 1, 1, [ 1, [ 4, 3, 7 ] ], g3 ] ],
+    edges = [ [ 1, 1, [ 1, [ [ 1, 1 ], 1, 5 ] ], g1 ], 
+	[ 1, 1, [ 1, [ [ 1, 2 ], 4, 8 ] ], g4 ], ... ],
     faces = [ [ [ 1, -1 ], [ 2, -1 ], [ 4, 1 ], [ 3, -1 ], [ 1, 1 ], [ 2, 1 ],
         [ 4, -1 ], [ 3, 1 ] ] ]
 )
@@ -154,7 +154,7 @@ TGSuperCellModelGraph(
     center = 3,
     type = [ "TESS", [ 8, 8 ], [ "VEF", [ [ 3 ], [ 1 ], [ 2 ] ] ] ],
     vertices = [ [ 3, 1, 1 ], [ 3, 1, 2 ] ],
-    edges = [ [ 1, 2, [ 1, 1, [ 1, [ 1, 1, 5 ] ] ], <identity ...> ], ... ],
+    edges = [ [ 1, 2, [ 1, 1, [ 1, [ [ 1, 1 ], 1, 5 ] ] ], <identity ...> ],...],
     faces = [ ]
 )
 @EndExampleSession
@@ -233,7 +233,7 @@ TGSuperCellModelGraph(
     center = 3,
     type = [ "TESS", [ 8, 8 ], [ "VEF", [ [ 3 ], [ 1 ], [ 2 ] ] ] ],
     vertices = [ [ 3, 1, 1 ], [ 3, 1, 2 ] ],
-    edges = [ [ 1, 2, [ 1, 1, [ 1, [ 1, 1, 5 ] ] ], <identity ...> ], ... ],
+    edges = [ [ 1, 2, [ 1, 1, [ 1, [ [ 1, 1 ], 1, 5 ] ] ], <identity ...> ],...],
     faces = [ ]
 )
 @EndExampleSession


### PR DESCRIPTION
This PR corrects the deprecated edge-tags prior to version 1.0.0, which use the cell graph edge vertices ve = g in the documentation Section 1.1.. The updated edge-tags reference the cell graph edge vertices ve = [w, g].