### PR TITLE
feat: add optional argument TGCell/TGCellGraph

### DIFF
--- a/gap/PGMatrix.gd
+++ b/gap/PGMatrix.gd
@@ -56,12 +56,16 @@ DeclareCategory( "IsPGMatricesOfGeneratorsObj", IsObject );
 #!   use of the embedding homomorphism from the proper triangle group $\Delta^+$ to the triangle group $\Delta$, 
 #!   where the former is specified by the `ProperTriangleGroup` object <A>tg</A> (see <Ref Sect="Section_TriangleGroups"/>).
 #!
+#!   Optionally, a TGCell object or a TGCellGraph object <A>TGce</A> can be given derived from the triangle group quotient 
+#!   <A>tgquotient</A>. If not given, the point-group matrices are constructed from the automatically generated cell of the
+#!   triangle group specified by <A>tgquotient</A> using the function <Ref Func='TGCell'/>.
+#!
 #!   The option `sparse`, which takes a boolean, can be used to generate a sparse 
 #!   representation of the point-group matrices. If `sparse` is `true`, the point-group matrices are of the
 #!   form `[ [ [ rowIdx, colIdx ], entry ], ... ]`, where `entry` is the corresponding matrix element at
 #!   position `rowIdx` and `colIdx`, which represent indices of the matrix rows and columns, 
 #!   respectively. The default is `false`. 
-#! @Arguments fulltg, tg, tgquotient
+#! @Arguments fulltg, tg, tgquotient[,TGce]
 #! @Returns the point-group matrices of the (full) triangle group generators `a`, `b` and `c` as a
 #!   `PGMatricesOfGenerators` object.
 DeclareGlobalFunction( "PGMatricesOfGenerators" );

--- a/gap/PGMatrix.gd
+++ b/gap/PGMatrix.gd
@@ -56,7 +56,7 @@ DeclareCategory( "IsPGMatricesOfGeneratorsObj", IsObject );
 #!   use of the embedding homomorphism from the proper triangle group $\Delta^+$ to the triangle group $\Delta$, 
 #!   where the former is specified by the `ProperTriangleGroup` object <A>tg</A> (see <Ref Sect="Section_TriangleGroups"/>).
 #!
-#!   Optionally, a TGCell object or a TGCellGraph object <A>TGce</A> can be given derived from the triangle group quotient 
+#!   Optionally, a `TGCell` object or a `TGCellGraph` object <A>cell</A> can be given derived from the triangle group quotient 
 #!   <A>tgquotient</A>. If not given, the point-group matrices are constructed from the automatically generated cell of the
 #!   triangle group specified by <A>tgquotient</A> using the function <Ref Func='TGCell'/>.
 #!
@@ -65,7 +65,7 @@ DeclareCategory( "IsPGMatricesOfGeneratorsObj", IsObject );
 #!   form `[ [ [ rowIdx, colIdx ], entry ], ... ]`, where `entry` is the corresponding matrix element at
 #!   position `rowIdx` and `colIdx`, which represent indices of the matrix rows and columns, 
 #!   respectively. The default is `false`. 
-#! @Arguments fulltg, tg, tgquotient[,TGce]
+#! @Arguments fulltg, tg, tgquotient[,cell]
 #! @Returns the point-group matrices of the (full) triangle group generators `a`, `b` and `c` as a
 #!   `PGMatricesOfGenerators` object.
 DeclareGlobalFunction( "PGMatricesOfGenerators" );

--- a/gap/PGMatrix.gi
+++ b/gap/PGMatrix.gi
@@ -109,10 +109,10 @@ function(fulltg, tg, tgquotient, args...)
 
     if Length(args) > 0 then
         if not (IsTGCellObj(args[1]) or IsTGCellGraphObj(args[1])) then
-            Error("The optional argument must be a TGCell object or a TGCellGraph object.");
+            Error("The optional argument must be a TGCell or TGCellGraph object.");
             return fail;
 	elif not GetProperTriangleGroup(args[1]) = tg then 
-            Error("The optional argument must have the same signature as the arguments.");
+            Error("The optional argument must be derived from the triangle group tg.");
             return fail;
         fi;	
     fi;
@@ -189,7 +189,7 @@ function(fulltg, tg, tgquotient, args...)
     # check quotient equivalence via the translation groups
     if Length(args) > 0 then
         if not AsTGSubgroup(cellGamma) = AsTGSubgroup(TGTranslationGroup(tg, tgquotient)) then
-            Error("The optional argument must be derived from the third argument.");
+            Error("The optional argument must be derived from the quotient tgquotient.");
             return fail;
         fi;
     fi;

--- a/gap/PGMatrix.gi
+++ b/gap/PGMatrix.gi
@@ -74,9 +74,9 @@ end );
 
 
 InstallGlobalFunction( PGMatricesOfGenerators,
-function(fulltg, tg, tgquotient)
+function(fulltg, tg, tgquotient, args...)
     local signature, sparse, quotient, D, DELTA, symmetries, embDDELTA, G, rels,
-     relsfull, cellGamma, GAMMA, fpGAMMA, gensGamma, gensGammaABC, gensGammaFp, 
+     relsfull, cellGamma, fpGAMMA, gensGamma, gensGammaABC, gensGammaFp, 
      homDeltaG, kernDeltaG, isoGamma, PGMRawLst, PGMatrixRaw, transOp, trans1, 
      trans2, tempGroup, homtemp, PGMLst, lst, matInt, item, i, j, entry, 
      row, symNames, idn, F, tgFpObjs, cell, Gplus, pgMatsRec;
@@ -100,9 +100,23 @@ function(fulltg, tg, tgquotient)
     fi;
 
     if not  Signature(fulltg) = Signature(tg) or not  Signature(tg) = TriangleGroupSignature(tgquotient) then
-        Error("The arguments must have the same signatures.");
+   	Error("The arguments must have the same signatures.");
         return fail;
     fi;
+
+    # Check optional argument:
+    # ------------------------
+
+    if Length(args) > 0 then
+        if not (IsTGCellObj(args[1]) or IsTGCellGraphObj(args[1])) then
+            Error("The optional argument must be a TGCell object or a TGCellGraph object.");
+            return fail;
+	elif not GetProperTriangleGroup(args[1]) = tg then 
+            Error("The optional argument must have the same signature as the arguments.");
+            return fail;
+        fi;	
+    fi;
+
 
     # --------------
     # Check options:
@@ -121,7 +135,16 @@ function(fulltg, tg, tgquotient)
     # ---------------
 
     signature := TriangleGroupSignature(tgquotient);
-    cell := TGCell(tg, tgquotient);
+
+    if Length(args) > 0 then
+        if IsTGCellGraphObj(args[1]) then
+            cell := GetTGCell(args[1]);
+        else
+            cell := args[1];
+        fi;
+    else
+        cell := TGCell(tg, tgquotient);
+    fi;
 
     # --------------------------------------------------
     # Construct groups, symmetry elements and embedding:
@@ -159,13 +182,20 @@ function(fulltg, tg, tgquotient)
     # ------------------
     # Perform embedding:
     # ------------------
-     
+
     # get point group and translation group obj.s
     cellGamma := TGCellTranslationGroup(cell); 
 
+    # check quotient equivalence via the translation groups
+    if Length(args) > 0 then
+        if not AsTGSubgroup(cellGamma) = AsTGSubgroup(TGTranslationGroup(tg, tgquotient)) then
+            Error("The optional argument must be derived from the third argument.");
+            return fail;
+        fi;
+    fi;
+
     # construct translation group
-    GAMMA := AsTGSubgroup(cellGamma);
-    gensGamma := GeneratorsOfGroup(GAMMA);	
+    gensGamma := Generators(cellGamma);	
 
     # get translation op.'s in terms of reflection op.'s
     # Note: I explicitly want these generators (in x, y, z) s.t. the 

--- a/gap/TGCell.gd
+++ b/gap/TGCell.gd
@@ -54,7 +54,7 @@
 DeclareGlobalFunction( "TGCell" );
 
 #! @Description
-#!   Construct the **symmetric** and at `center`centered cell for the triangle group
+#!   Construct the **symmetric** and at `center` centered cell for the triangle group
 #!   <A>tg</A> ($\Delta^+$), given as `ProperTriangleGroup` object
 #!   (see <Ref Sect="Section_TriangleGroups"/>), specified by the quotient <A>q</A>
 #!   given as a `TGQuotient` object <A>quotient</A>

--- a/gap/TGCellGraph.gd
+++ b/gap/TGCellGraph.gd
@@ -164,7 +164,7 @@ DeclareOperation( "CellFacesWithCenter", [ IsTGCellGraphObj ] );
 #!   Each boundary is described by a list of the form `[ d1, d2, e, b, m, gam ]`,
 #!   where `d1`, `d2` are elements of $T_{\Delta^+}(\Gamma)\subset\Delta^+$ labeling
 #!   the Schwarz triangles this edge is a part of, `e` the position in the list of
-#!   edges `CellEdges(`<A>celgraph</A>`)`, `b` the index of the boundary (identical
+#!   edges `CellEdges(`<A>cellgraph</A>`)`, `b` the index of the boundary (identical
 #!   for identified boundaries), `m` either 0 or 1 indicating the orientation of the
 #!   triangle associated with this instance of the boundary (0 for gray and 1 for white),
 #!   and `gam` the translation relating the given to the identified boundary, as

--- a/gap/TGCellModelGraph.gd
+++ b/gap/TGCellModelGraph.gd
@@ -207,11 +207,11 @@ DeclareGlobalFunction( "KagomeModelGraph" );
 #!   @BeginLog
 #! [ "LIEB", [ p, q ], [ "VEF", [ [ 1, 2 ], [  ], [ 3 ] ] ] ]
 #!   @EndLog
-#!   for the $\{p,q\}$ tesselation and to
+#!   for the $\{p,q\}$ tessellation and to
 #!   @BeginLog
 #! [ "LIEB", [ q, p ], [ "VEF", [ [ 1, 3 ], [  ], [ 2 ] ] ] ]
 #!   @EndLog
-#!   for the $\{q,p\}$ tesselation.
+#!   for the $\{q,p\}$ tessellation.
 #!   The edge tags are given in the same format as in <Ref Func='TGCellModelGraph'/>.
 #! @Arguments cellgraph[,dual]
 #! @Returns the model graph as `TGCellModelGraph` object
@@ -282,11 +282,11 @@ DeclareOperation( "GetTGCell", [ IsTGCellModelGraphObj ] );
 #!     @BeginLog
 #! [ "LIEB", [ p, q ], [ "VEF", [ [ 1, 2 ], [  ], [ 3 ] ] ] ]
 #!     @EndLog
-#!     for the $\{p,q\}$ tesselation and as
+#!     for the $\{p,q\}$ tessellation and as
 #!     @BeginLog
 #! [ "LIEB", [ q, p ], [ "VEF", [ [ 1, 3 ], [  ], [ 2 ] ] ] ]
 #!     @EndLog
-#!     for the (dual) $\{q,p\}$ tesselation.
+#!     for the (dual) $\{q,p\}$ tessellation.
 #!     See <Ref Func='LiebModelGraph'/> for details.
 #! @Arguments model
 #! @Label for TGCellModelGraph

--- a/tst/PGMatrix.tst
+++ b/tst/PGMatrix.tst
@@ -11,7 +11,7 @@ gap> cell_graph := TGCellGraph( tg, qpc, 3 );;
 gap> Mz := [ [ 0, 1, 0, 0 ], [ 0, 0, 1, 0 ], [ 0, 0, 0, 1 ], [ -1, 0, -1, 0 ] ];;
 
 # FpGroups and symmetry elements
-gap> sym := FpGroup(tg).3;
+gap> sym := FpGroup(tg).3;;
 gap> pgMatGs := PGMatricesOfGenerators(fulltg, tg, qpc, cell_graph);;
 gap> EvaluatePGMatrix(sym, pgMatGs) = Mz;
 true

--- a/tst/PGMatrix.tst
+++ b/tst/PGMatrix.tst
@@ -1,5 +1,21 @@
 gap> START_TEST("HyperCells: PGMatrix.tst");
 
+
+# Preliminary test: Triangle group (2,4,6)
+gap> fulltg := TriangleGroup( [ 2, 4, 6 ] );;
+gap> tg := ProperTriangleGroup( [ 2, 4, 6 ] );;
+gap> qpc := TGQuotient( 1, [ 2, 4, 6 ] );;
+gap> cell_graph := TGCellGraph( tg, qpc, 3 );;
+
+# Define known point-group matrix:
+gap> Mz := [ [ 0, 1, 0, 0 ], [ 0, 0, 1, 0 ], [ 0, 0, 0, 1 ], [ -1, 0, -1, 0 ] ];;
+
+# FpGroups and symmetry elements
+gap> sym := FpGroup(tg).3;
+gap> pgMatGs := PGMatricesOfGenerators(fulltg, tg, qpc, cell_graph);;
+gap> EvaluatePGMatrix(sym, pgMatGs) = Mz;
+true
+
 # Triangle group (2,8,8)
 gap> fulltg := TriangleGroup( [ 2, 8, 8 ] );;
 gap> tg := ProperTriangleGroup( [ 2, 8, 8 ] );;

--- a/tst/PGMatrix.tst
+++ b/tst/PGMatrix.tst
@@ -4,12 +4,28 @@ gap> START_TEST("HyperCells: PGMatrix.tst");
 gap> fulltg := TriangleGroup( [ 2, 8, 8 ] );;
 gap> tg := ProperTriangleGroup( [ 2, 8, 8 ] );;
 gap> qpc := TGQuotient( 1, [ 2, 8, 8 ] );;
+gap> cell_graph := TGCellGraph( tg, qpc, 3 );;
+gap> cell := GetTGCell( cell_graph );;
 
 # FpGroups and symmetry elements
 gap> D := FpGroup(tg);;
 gap> DELTA := FpGroup(fulltg);;
 gap> symmetries := [DELTA.1, DELTA.2, DELTA.3, D.1, D.2, D.3, D.3^-1, D.3*D.3^-1, DELTA.2*DELTA.1*DELTA.3, D.1*D.2];;
 gap> symNames := ["A", "B", "C", "X", "Y", "Z", "z^-1", "id", "BAC", "XY"];;
+
+gap> pgMatGs := PGMatricesOfGenerators(fulltg, tg, qpc, cell_graph);
+PGMatricesOfGenerators( TriangleGroup(2, 8, 8), ProperTriangleGroup(2, 8, 8), TGQuotient([ 2, 6 ], [ 2, 8, 8 ], 8, 2, \
+Action reflexible [m,n], [ x^2, x * y * z, x * z * y, y^3 * z^-1 ]), sparse = false, tgGenerators = [ a, b, c ], pgMat\
+ricesRec = rec( a := [ [ 1, 0, 0, 0 ], [ 0, 0, 0, -1 ], [ 0, 0, -1, 0 ], [ 0, -1, 0, 0 ] ], b := [ [ -1, 0, 0, 0 ], [ \
+0, 0, 0, 1 ], [ 0, 0, 1, 0 ], [ 0, 1, 0, 0 ] ], c := [ [ 0, 0, 0, -1 ], [ 0, 0, -1, 0 ], [ 0, -1, 0, 0 ], [ -1, 0, 0, \
+0 ] ] ))
+
+gap> pgMatGs := PGMatricesOfGenerators(fulltg, tg, qpc, cell);
+PGMatricesOfGenerators( TriangleGroup(2, 8, 8), ProperTriangleGroup(2, 8, 8), TGQuotient([ 2, 6 ], [ 2, 8, 8 ], 8, 2, \
+Action reflexible [m,n], [ x^2, x * y * z, x * z * y, y^3 * z^-1 ]), sparse = false, tgGenerators = [ a, b, c ], pgMat\
+ricesRec = rec( a := [ [ 1, 0, 0, 0 ], [ 0, 0, 0, -1 ], [ 0, 0, -1, 0 ], [ 0, -1, 0, 0 ] ], b := [ [ -1, 0, 0, 0 ], [ \
+0, 0, 0, 1 ], [ 0, 0, 1, 0 ], [ 0, 1, 0, 0 ] ], c := [ [ 0, 0, 0, -1 ], [ 0, 0, -1, 0 ], [ 0, -1, 0, 0 ], [ -1, 0, 0, \
+0 ] ] ))
 
 gap> pgMatGs := PGMatricesOfGenerators(fulltg, tg, qpc);
 PGMatricesOfGenerators( TriangleGroup(2, 8, 8), ProperTriangleGroup(2, 8, 8), TGQuotient([ 2, 6 ], [ 2, 8, 8 ], 8, 2, \
@@ -280,6 +296,24 @@ true
 
 # Test on supercell
 gap> qsc := TGQuotient( [3, 11] );;
+gap> cell_graph_sc := TGCellGraph( tg, qsc, 3 );;
+gap> cell_sc := GetTGCell( cell_graph_sc );;
+
+gap> pgMatGs := PGMatricesOfGenerators(fulltg, tg, qsc, cell_graph_sc);
+PGMatricesOfGenerators( TriangleGroup(2, 8, 8), ProperTriangleGroup(2, 8, 8), TGQuotient([ 3, 11 ], [ 2, 8, 8 ], 16, 3\
+, Action reflexible [m,n], [ x^2, x * y * z, x * z * y, y^-8 ]), sparse = false, tgGenerators = [ a, b, c ], pgMatrice\
+sRec = rec( a := [ [ 0, -1, 0, 0, 0, 0 ], [ -1, 0, 0, 0, 0, 0 ], [ 0, 1, 0, 1, 0, 1 ], [ 1, 0, 1, 0, 1, 0 ], [ 0, 0, 0\
+, 0, 0, -1 ], [ 0, 0, 0, 0, -1, 0 ] ], b := [ [ 0, 1, 0, 0, 0, 0 ], [ 1, 0, 0, 0, 0, 0 ], [ 0, -1, 0, -1, 0, -1 ], [ -\
+1, 0, -1, 0, -1, 0 ], [ 0, 0, 0, 0, 0, 1 ], [ 0, 0, 0, 0, 1, 0 ] ], c := [ [ -1, 0, 0, 0, 0, 0 ], [ 0, 1, 0, 1, 0, 1 ]\
+, [ 1, 0, 1, 0, 1, 0 ], [ 0, 0, 0, 0, 0, -1 ], [ 0, 0, 0, 0, -1, 0 ], [ 0, 0, 0, -1, 0, 0 ] ] ))
+
+gap> pgMatGs := PGMatricesOfGenerators(fulltg, tg, qsc, cell_sc);
+PGMatricesOfGenerators( TriangleGroup(2, 8, 8), ProperTriangleGroup(2, 8, 8), TGQuotient([ 3, 11 ], [ 2, 8, 8 ], 16, 3\
+, Action reflexible [m,n], [ x^2, x * y * z, x * z * y, y^-8 ]), sparse = false, tgGenerators = [ a, b, c ], pgMatrice\
+sRec = rec( a := [ [ 0, -1, 0, 0, 0, 0 ], [ -1, 0, 0, 0, 0, 0 ], [ 0, 1, 0, 1, 0, 1 ], [ 1, 0, 1, 0, 1, 0 ], [ 0, 0, 0\
+, 0, 0, -1 ], [ 0, 0, 0, 0, -1, 0 ] ], b := [ [ 0, 1, 0, 0, 0, 0 ], [ 1, 0, 0, 0, 0, 0 ], [ 0, -1, 0, -1, 0, -1 ], [ -\
+1, 0, -1, 0, -1, 0 ], [ 0, 0, 0, 0, 0, 1 ], [ 0, 0, 0, 0, 1, 0 ] ], c := [ [ -1, 0, 0, 0, 0, 0 ], [ 0, 1, 0, 1, 0, 1 ]\
+, [ 1, 0, 1, 0, 1, 0 ], [ 0, 0, 0, 0, 0, -1 ], [ 0, 0, 0, 0, -1, 0 ], [ 0, 0, 0, -1, 0, 0 ] ] ))
 
 gap> pgMatGs := PGMatricesOfGenerators(fulltg, tg, qsc);
 PGMatricesOfGenerators( TriangleGroup(2, 8, 8), ProperTriangleGroup(2, 8, 8), TGQuotient([ 3, 11 ], [ 2, 8, 8 ], 16, 3\


### PR DESCRIPTION
The function PGMatricesOfGenerators(fulltg, tg, tgquotient) is enhanced through the inclusion of an optional argument PGMatricesOfGenerators(fulltg, tg, tgquotient[,cell]), where cell is a TGCell (or TGCellGraph) object derived from tgquotient. This enables the user to construct point-group matrices explicitly specified through the user-constructed TGCell (or TGCellGraph) object. If the optional argument is not provided, HyperCells automatically generates the cell based on the function TGCell.